### PR TITLE
add info_response table

### DIFF
--- a/stat_persistor/saver/statsaver.py
+++ b/stat_persistor/saver/statsaver.py
@@ -79,6 +79,10 @@ class StatSaver(object):
                                      autoload=True,
                                      schema='stat')
 
+        self.info_response = Table('info_response', self.meta,
+                                     autoload=True,
+                                     schema='stat')
+
         self.filter = Table('filter', self.meta,
                                      autoload=True,
                                      schema='stat')


### PR DESCRIPTION
missing in https://github.com/CanalTP/navitia-stat-persistor/pull/2