### PR TITLE
Add some indexes

### DIFF
--- a/migrations/alembic/versions/46225529a0eb_add_index_on_coverages.py
+++ b/migrations/alembic/versions/46225529a0eb_add_index_on_coverages.py
@@ -1,0 +1,20 @@
+"""Add index on coverages
+
+Revision ID: 46225529a0eb
+Revises: fos5a55d7a
+Create Date: 2015-10-21 13:04:27.432973
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '46225529a0eb'
+down_revision = 'fos5a55d7a'
+
+from alembic import op
+
+def upgrade():
+    op.create_index('coverages_request_id_idx', 'coverages', ['request_id'], schema='stat')
+
+
+def downgrade():
+    op.drop_index('coverages_request_id_idx', schema='stat')

--- a/migrations/alembic/versions/466453911d1c_add_index_on_journey_sections.py
+++ b/migrations/alembic/versions/466453911d1c_add_index_on_journey_sections.py
@@ -1,0 +1,22 @@
+"""Add index on journey_sections
+
+Revision ID: 466453911d1c
+Revises: 46225529a0eb
+Create Date: 2015-10-26 09:40:36.708169
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '466453911d1c'
+down_revision = '46225529a0eb'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_index('journey_sections_request_id_idx', 'journey_sections', ['request_id'], schema='stat')
+
+
+def downgrade():
+    op.drop_index('journey_sections_request_id_idx', schema='stat')


### PR DESCRIPTION
In order to speed up consolidation processes, and avoid a timeout when query lasts more than 2 hours.

A cleanup of already existing indexes will be done later (but soon)