### PR TITLE
Order and head migration fixed.

### DIFF
--- a/migrations/alembic/versions/372e4c6a8689_add_index_on_info_response.py
+++ b/migrations/alembic/versions/372e4c6a8689_add_index_on_info_response.py
@@ -8,7 +8,7 @@ Create Date: 2015-12-02 16:59:07.504196
 
 # revision identifiers, used by Alembic.
 revision = '372e4c6a8689'
-down_revision = '130355168524'
+down_revision = '26052d62719'
 
 from alembic import op
 import sqlalchemy as sa


### PR DESCRIPTION
# Introduction
*Head migration fixed.*

We have this error because we have two head in migrations.
```
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
ERROR [alembic.util.messaging] Multiple head revisions are present for given argument 'head'; please specify a specific target revision, '<branchname>@head' to narrow to a specific head, or 'heads' for all heads
  FAILED: Multiple head revisions are present for given argument 'head'; please specify a specific target revision, '<branchname>@head' to narrow to a
  specific head, or 'heads' for all heads
```
```
130355168524 -> 372e4c6a8689 (head), Add index on info_response
130355168524 -> 26052d62719 (head), column token added
466453911d1c -> 130355168524 (branchpoint), Cleanup some useless indexes
46225529a0eb -> 466453911d1c, Add index on journey_sections
fos5a55d7a -> 46225529a0eb, Add index on coverages
14a0ba4227ce -> fos5a55d7a, add info_response
18ef01ed8e1 -> 14a0ba4227ce, Add some indexes
25529bc17860 -> 18ef01ed8e1, add the end_point of a user
c2a0f6d88a4 -> 25529bc17860, add some basic indexes
2c90cc5083e6 -> c2a0f6d88a4, add_first_and_last_pt
d8cff35d69 -> 2c90cc5083e6, add_filter
75910df5976 -> d8cff35d69, add journey_request
236b716d0c88 -> 75910df5976, add intrepreted_parameters
176f17297061 -> 236b716d0c88, modify_id_type
<base> -> 176f17297061, create_all_tables
```

This PR fix order of last migrations.

## 1. How to test it ?

```
cd migrations && alembic upgrade head
cd .. && python stat_persist.py stat_persistor.json
```