### PR TITLE
Change exchange type for stat and bind to it with a joker routing_key

### DIFF
--- a/stat_persistor/daemon.py
+++ b/stat_persistor/daemon.py
@@ -64,12 +64,12 @@ class StatPersistor(ConsumerMixin):
         """
         self.connection = kombu.Connection(self.config.broker_url)
         exchange_name = self.config.exchange_name
-        exchange = kombu.Exchange(exchange_name, type="direct")
+        exchange = kombu.Exchange(exchange_name, type="topic")
         logging.getLogger('stat_persistor').info("listen following exchange: %s",
                                          self.config.exchange_name)
 
         queue_name = self.config.queue_name
-        queue = kombu.Queue(queue_name, exchange=exchange, durable=True)
+        queue = kombu.Queue(queue_name, exchange=exchange, routing_key='#', durable=True)
         self.queues.append(queue)
 
     def get_consumers(self, Consumer, channel):


### PR DESCRIPTION
This PR is needed to remain compatible with CanalTP/navitia#1663

This modification will need to be deployed **before** the navitia PR reaches production.

This will also suppose to change the exchange name according to the one chosen for Jormungandr